### PR TITLE
don't change the name of the test suite

### DIFF
--- a/src/Allure/Behat/Formatter/AllureFormatter.php
+++ b/src/Allure/Behat/Formatter/AllureFormatter.php
@@ -168,7 +168,7 @@ class AllureFormatter implements FormatterInterface
             $this->parameters->get('delete_previous_results')
         );
         $now = new DateTime();
-        $event = new TestSuiteStartedEvent(sprintf('TestSuite-%s', $now->format('Y-m-d_His')));
+        $event = new TestSuiteStartedEvent(sprintf('Behat TestSuite'));
 
         $this->uuid = $event->getUuid();
 


### PR DESCRIPTION
Maybe I'm getting this all wrong but generating a different name for each run of the test suit means there is no proper history on the tests if you compare it with how the phpunit adapter works. But could bet his is needed for some reason?