### PR TITLE
Added support for Allure 'epic' and 'feature' tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ Here:
  - `test_id_tag_prefix` - tag with this prefix will be interpreted as Test Case Id marker and will generate TMS link for
  test case (using [**allure.tests.management.pattern** setting for allure-cli](https://github.com/allure-framework/allure-core/wiki/Test-Case-ID))
 
+Optionally, you can add the following options:
+ - `epic_tag_prefix` - tags with this prefix will be added as Allure Epic tags
+ - `feature_tag_prefix` - tags with this prefix will be added as Allure Feature tags
+ - `story_tag_prefix` - tags with this prefix will be added as Allure Story tags, if you set `story_tag_prefix: "."` the story tag will be filled with the name of the feature name
 
 ### Use attachment support
 To have attachments in allure report - make sure your behat runs tests with [Mink](https://github.com/minkphp/Mink)
@@ -85,6 +89,38 @@ Behat also has tags and they are also can be used in Allure reports:
 * If a tag starts with test_id_tag_prefix, then formatter will interpret it's affixed part as
 [Test Case Id](https://github.com/allure-framework/allure-core/wiki/Test-Case-ID) for your TMS
 * In all other cases tag will be parsed as Allure Story annotation
+
+### Alternative configuration
+
+You can change this standard behaviour by setting the `epic_tag_prefix`, `feature_tag_prefix` and `story_tag_prefix`.
+
+#### Example using BDD capabilities and features
+- `feature_tag_prefix= "Capability:"`
+- `story_tag_prefix= "."`
+
+A `test.feature` file with the following content:
+
+@Capability:Customers
+    Feature: Creating new customers
+
+Will report the results as:
+- Customers
+-- Creating new customers
+
+#### Example using BDD business domains, capabilities and features
+- `epic_tag_prefix= "BusinessDomain:"`
+- `feature_tag_prefix= "Capability:"`
+- `story_tag_prefix= "."`
+
+A `test.feature` file with the following content:
+
+@BusinessDomain:CRM @Capability:Customers
+    Feature: Creating new customers
+
+Will report the results as:
+- CRM
+-- Customers
+--- Creating new customers
 
 ### Contribution?
 Feel free to open PR with changes but before pls make sure you pass tests

--- a/README.md
+++ b/README.md
@@ -95,32 +95,44 @@ Behat also has tags and they are also can be used in Allure reports:
 You can change this standard behaviour by setting the `epic_tag_prefix`, `feature_tag_prefix` and `story_tag_prefix`.
 
 #### Example using BDD capabilities and features
-- `feature_tag_prefix= "Capability:"`
-- `story_tag_prefix= "."`
+```yml
+feature_tag_prefix: "Capability:"
+story_tag_prefix: "."
+```
 
 A `test.feature` file with the following content:
 
+```
 @Capability:Customers
     Feature: Creating new customers
+```
 
 Will report the results as:
-- Customers
--- Creating new customers
+```
+Customers
+    Creating new customers
+```
 
 #### Example using BDD business domains, capabilities and features
-- `epic_tag_prefix= "BusinessDomain:"`
-- `feature_tag_prefix= "Capability:"`
-- `story_tag_prefix= "."`
+```yml
+epic_tag_prefix: "BusinessDomain:"
+feature_tag_prefix: "Capability:"
+story_tag_prefix: "."
+```
 
 A `test.feature` file with the following content:
 
+```
 @BusinessDomain:CRM @Capability:Customers
     Feature: Creating new customers
+```
 
 Will report the results as:
-- CRM
--- Customers
---- Creating new customers
+```
+CRM
+    Customers
+        Creating new customers
+```
 
 ### Contribution?
 Feel free to open PR with changes but before pls make sure you pass tests

--- a/composer.json
+++ b/composer.json
@@ -19,12 +19,12 @@
   ],
   "require": {
     "php": ">=5.5",
-    "behat/behat": "^3.3",
-    "allure-framework/allure-php-api": "~1.1.4"
+    "behat/behat": "^3.3"
   },
   "require-dev": {
     "symfony/process": "~2.5|~3.0|~4.0",
-    "phpunit/phpunit": "^4.8.36|^6.3"
+    "phpunit/phpunit": "^4.8.36|^6.3",
+    "allure-framework/allure-php-api": "~1.1.5"
   },
   "autoload": {
     "psr-0": {

--- a/src/Allure/Behat/AllureFormatterExtension.php
+++ b/src/Allure/Behat/AllureFormatterExtension.php
@@ -79,6 +79,9 @@ class AllureFormatterExtension implements ExtensionInterface
     $builder->children()->scalarNode("test_id_tag_prefix")->defaultValue(null);
     $builder->children()->scalarNode("ignored_tags")->defaultValue(null);
     $builder->children()->scalarNode("severity_key")->defaultValue(null);
+    $builder->children()->scalarNode("epic_tag_prefix")->defaultValue(null);
+    $builder->children()->scalarNode("feature_tag_prefix")->defaultValue(null);
+    $builder->children()->scalarNode("story_tag_prefix")->defaultValue(null);
   }
 
   /**
@@ -95,6 +98,9 @@ class AllureFormatterExtension implements ExtensionInterface
     $definition->addArgument($config['test_id_tag_prefix']);
     $definition->addArgument($config['ignored_tags']);
     $definition->addArgument($config['severity_key']);
+    $definition->addArgument($config['epic_tag_prefix']);
+    $definition->addArgument($config['feature_tag_prefix']);
+    $definition->addArgument($config['story_tag_prefix']);
     $definition->addArgument('%paths.base%');
     $presenter = new Reference(ExceptionExtension::PRESENTER_ID);
     $definition->addArgument($presenter);


### PR DESCRIPTION
To fully use Allure's reporting capabilities and its grouping, it's useful to be able to set the epic and feature tags. This is related to pull request https://github.com/allure-framework/allure-php-commons/pull/43.