### PR TITLE
Check for value of $this->severity_key prior to stripos

### DIFF
--- a/src/Allure/Behat/Formatter/AllureFormatter.php
+++ b/src/Allure/Behat/Formatter/AllureFormatter.php
@@ -420,16 +420,18 @@ class AllureFormatter implements Formatter
         }
       }
 
-      if (stripos($tag, $this->severity_key) === 0) {
-        $level = preg_replace("/$this->severity_key/", '', $tag);
-        try {
-          $level = ConstantChecker::validate('Yandex\Allure\Adapter\Model\SeverityLevel', $level);
-          $severity->level = $level;
-        } catch (AllureException $e) {
-          $severity->level = SeverityLevel::NORMAL;
+      if ($this->severity_key) {
+        if (stripos($tag, $this->severity_key) === 0) {
+          $level = preg_replace("/$this->severity_key/", '', $tag);
+          try {
+            $level = ConstantChecker::validate('Yandex\Allure\Adapter\Model\SeverityLevel', $level);
+            $severity->level = $level;
+          } catch (AllureException $e) {
+            $severity->level = SeverityLevel::NORMAL;
+          }
+          array_push($annotations, $severity);
+          continue;
         }
-        array_push($annotations, $severity);
-        continue;
       }
 
       $story->stories[] = $tag;


### PR DESCRIPTION
In src/Allure/Behat/Formatter/AllureFormatter.php the check `if (stripos($tag, $this->severity_key) === 0) {` happens without checking if `$this->severity_key` has a value. With PHP 7.4 non-string needles are being interpreted as string and of `$this->severity_key` has e.g. the value of `NULL` results in an error.