### PR TITLE
fix: bump symfony/process to avoid CVE-2024-51736

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,9 @@ on:
       - 'master'
       - 'hotfix-*'
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,57 +10,16 @@ on:
       - 'hotfix-*'
 
 jobs:
-  build71:
+  test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php-version: ["7.4", "8.1", "8.2", "8.3", "8.4"]
     steps:
-      - uses: actions/checkout@v2.3.4
-      - uses: shivammathur/setup-php@2.11.0
+      - uses: actions/checkout@v5
+      - uses: shivammathur/setup-php@2.35.4
         with:
-          php-version: '7.1.3'
-      - name: Install
-        run: composer update
-      - name: Test
-        run: composer test
-  build72:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2.3.4
-      - uses: shivammathur/setup-php@2.11.0
-        with:
-          php-version: '7.2'
-      - name: Install
-        run: composer update
-      - name: Test
-        run: composer test
-  build73:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2.3.4
-      - uses: shivammathur/setup-php@2.11.0
-        with:
-          php-version: '7.3'
-      - name: Install
-        run: composer update
-      - name: Test
-        run: composer test
-  build74:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2.3.4
-      - uses: shivammathur/setup-php@2.11.0
-        with:
-          php-version: '7.4'
-      - name: Install
-        run: composer update
-      - name: Test
-        run: composer test
-  build80:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2.3.4
-      - uses: shivammathur/setup-php@2.11.0
-        with:
-          php-version: '8.0'
+          php-version: "${{ matrix.php-version }}"
       - name: Install
         run: composer update
       - name: Test

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -5,9 +5,15 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 jobs:
   update_draft_release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: toolmantim/release-drafter@v5.15.0
         env:

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -15,6 +15,6 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: toolmantim/release-drafter@v5.15.0
+      - uses: toolmantim/release-drafter@v6.1.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/labels-verify.yml
+++ b/.github/workflows/labels-verify.yml
@@ -4,9 +4,14 @@ on:
   pull_request:
     types: [opened, labeled, unlabeled, synchronize]
 
+permissions:
+  contents: none
+
 jobs:
   triage:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
     steps:
       - uses: baev/match-label-action@master
         with:

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "allure-framework/allure-php-api": "^1.3"
   },
   "require-dev": {
-    "symfony/process": "~2.5|~3.0|~4.0",
+    "symfony/process": "^5.4.46 | ^6.4.14 | ^7.1.7",
     "phpunit/phpunit": "^7.2 | ^8 | ^9"
   },
   "autoload": {


### PR DESCRIPTION
CVE-2024-51736 is fixed in symfony/process 5.4.46, 6.4.14, and 7.1.7. The PR updates the required versions accordingly and modifies the `Process` usage for the changed API.

#### Extra changes

  - Rewrite build workflow to use matrix
  - Update target php versions of build workflow to 7.4, 8.1, 8.2, 8.3, and 8.4 (all currently supported versions plus the latest php 7 version)
  - Set explicit permissions for workflows
  - Bump toolmantim/release-drafter to v6.1.0
  - Bump actions/checkout to v5
  - Bump shivammathur/setup-php to 2.35.4